### PR TITLE
 Removing 5% full payment discount for CA webiste

### DIFF
--- a/source/english/payment.html.haml
+++ b/source/english/payment.html.haml
@@ -73,8 +73,11 @@
               %strong
                 59 000 SEK
     .centered-row
-      %h3 Full at registration = 5% discount
-      %p You can choose to pay the full course fee upon admission to any of our programs and receive a 5% discount.
+      %h3 Female participants
+      %p.copy--center
+        We also offer <strong>5%</strong> discount to all female students. (We think that gender inequality sucks, and we want to do whatever we can to help put. You don't like it? Sue us!).
+      -# %h3 Full at registration = 5% discount
+      -# %p You can choose to pay the full course fee upon admission to any of our programs and receive a 5% discount.
       %table.responsive-table
         %thead.backgrounded
           %tr
@@ -151,10 +154,10 @@
     -#   %small  * Interest-free installments are normaly offered to students residing in Sweden and in special cases to EU residents.
     -#   %br
     -#     %small Regular credit check will be carried out. Monthly installments include a 75 SEK service fee.
-    .centered-row
-      %h3 Female participants
-      %p.copy--center
-        We also offer <strong>another 5%</strong> discount to all female students. (We think that gender inequality sucks, and we want to do whatever we can to help put. You don't like it? Sue us!).
-        %strong Please note:
-        The 5% discount offered to female bootcamp participants will be applied on top of the other discounts.
+    -# .centered-row
+    -#   %h3 Female participants
+    -#   %p.copy--center
+    -#     We also offer <strong>another 5%</strong> discount to all female students. (We think that gender inequality sucks, and we want to do whatever we can to help put. You don't like it? Sue us!).
+        -# %strong Please note:
+        -# The 5% discount offered to female bootcamp participants will be applied on top of the other discounts.
 = partial :'/english/partials/_apply.html.haml'

--- a/source/payment.html.haml
+++ b/source/payment.html.haml
@@ -81,8 +81,12 @@
               %strong
                 59 000 kr
     .centered-row
-      %h3 Boka Tidigt-rabatt
-      %p Du kan välja att betala hela kursavgiften vid antagning till något av våra program och erhålla 5% rabatt.
+      %h3 Kvinnliga sökande
+      %p.copy--center
+        Vi erbjuder <strong>ytterligare 5%</strong> rabatt på ovanstående priser till kvinnliga sökande eftersom kvinnor är mycket underrepresenterade i IT-branschen.
+        %strong Denna rabatt läggs till eventuella ovanstående rabatter.
+      -# %h3 Boka Tidigt-rabatt
+      -# %p Du kan välja att betala hela kursavgiften vid antagning till något av våra program och erhålla 5% rabatt.
       %table.responsive-table
         %thead.backgrounded
           %tr
@@ -155,11 +159,11 @@
     -#           %strong
     -#             126 800 kr
     -#   %small  * Räntefri delbetalning erbjuds studenter bosatta i Sverige. Sedvanlig kreditkontroll kommer att genomföras
-    .centered-row
-      %h3 Kvinnliga sökande
-      %p.copy--center
-        Vi erbjuder <strong>ytterligare 5%</strong> rabatt på ovanstående priser till kvinnliga sökande eftersom kvinnor är mycket underrepresenterade i IT-branschen.
-        %strong Denna rabatt läggs till eventuella ovanstående rabatter.
+    -# .centered-row
+    -#   %h3 Kvinnliga sökande
+    -#   %p.copy--center
+    -#     Vi erbjuder <strong>ytterligare 5%</strong> rabatt på ovanstående priser till kvinnliga sökande eftersom kvinnor är mycket underrepresenterade i IT-branschen.
+    -#     %strong Denna rabatt läggs till eventuella ovanstående rabatter.
 
 %section
   .container


### PR DESCRIPTION
 - I commented out the full payment discount from the English & Swedish version of the site.
- I also moved the Female 5% discount write above the discount price table.

![Screenshot 2019-11-04 at 09 55 29](https://user-images.githubusercontent.com/41902068/68109926-146dfc00-feec-11e9-9f69-565e557b0e68.png)


![Screenshot 2019-11-04 at 09 55 50](https://user-images.githubusercontent.com/41902068/68109931-1768ec80-feec-11e9-92d3-97b939ab433d.png)
