### PR TITLE
Increasing pricing of the bootcamp

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -126,14 +126,14 @@ redirect 'pretoria.html', to: 'south-africa.html'
 redirect 'south-africa.html', to: 'english/za/index.html'
 
 # HACK: Comment this section out while in development
-activate :deploy do |deploy|
-  deploy.method          = :rsync
-  deploy.host            = ENV.fetch('HOST')
-  deploy.path            = ENV.fetch('DEPLOY_PATH')
-  deploy.user            = ENV.fetch('DEPLOY_USER')
-  deploy.build_before    = true
-  deploy.clean           = true
-end
+# activate :deploy do |deploy|
+#   deploy.method          = :rsync
+#   deploy.host            = ENV.fetch('HOST')
+#   deploy.path            = ENV.fetch('DEPLOY_PATH')
+#   deploy.user            = ENV.fetch('DEPLOY_USER')
+#   deploy.build_before    = true
+#   deploy.clean           = true
+# end
 
 configure :development do
   activate :livereload

--- a/config.rb
+++ b/config.rb
@@ -126,14 +126,14 @@ redirect 'pretoria.html', to: 'south-africa.html'
 redirect 'south-africa.html', to: 'english/za/index.html'
 
 # HACK: Comment this section out while in development
-# activate :deploy do |deploy|
-#   deploy.method          = :rsync
-#   deploy.host            = ENV.fetch('HOST')
-#   deploy.path            = ENV.fetch('DEPLOY_PATH')
-#   deploy.user            = ENV.fetch('DEPLOY_USER')
-#   deploy.build_before    = true
-#   deploy.clean           = true
-# end
+activate :deploy do |deploy|
+  deploy.method          = :rsync
+  deploy.host            = ENV.fetch('HOST')
+  deploy.path            = ENV.fetch('DEPLOY_PATH')
+  deploy.user            = ENV.fetch('DEPLOY_USER')
+  deploy.build_before    = true
+  deploy.clean           = true
+end
 
 configure :development do
   activate :livereload

--- a/source/english/payment.html.haml
+++ b/source/english/payment.html.haml
@@ -1,4 +1,4 @@
-- description 'Our prices - Base Price for Craft Academy\'s Full Stack Developer Bootcamp is 97 700 SEK.'
+- description 'Our prices - Base Price for Craft Academy\'s Full Stack Developer Bootcamp is 99 500 SEK.'
 %section.hero-splash{style: "background-image: url(#{image_path('backgrounds/splash_4.jpg')});"}
   .container
     .centered-row
@@ -47,10 +47,10 @@
           %tr
             %td{data:{header: 'Program'}} Full Stack Web Developer
             %td{data:{header: 'At registration'}} 9 700 SEK
-            %td{data:{header: 'At course start'}} 87 300 SEK
+            %td{data:{header: 'At course start'}} 89 800 SEK
             %td{data:{header: 'Total'}}
               %strong
-                97 000 SEK
+                99 500 SEK
           -# %tr
           -#   %td{data:{header: 'Program'}} Enterprise Java Web Application Developer
           -#   %td{data:{header: 'At registration'}} 11 500 SEK
@@ -88,11 +88,11 @@
         %tbody
           %tr
             %td{data:{header: 'Program'}} Full Stack Web Developer
-            %td{data:{header: 'List price'}} 97 000 SEK
+            %td{data:{header: 'List price'}} 99 500 SEK
             %td{data:{header: 'Discount'}} 5 %
             %td{data:{header: 'Total at registration(incl. 25% VAT)'}}
               %strong
-                92 150 SEK
+                94 525 SEK
           -# %tr
           -#   %td{data:{header: 'Program'}} Enterprise Java Web Application Developer
           -#   %td{data:{header: 'List price'}} 115 000 SEK

--- a/source/english/payment.html.haml
+++ b/source/english/payment.html.haml
@@ -33,7 +33,7 @@
     .centered-row
       %h2 Payment and Funding Options
       %p.copy
-        The Craft Academy Boot Camp is a private education and thus does not qualify for CSN support. You can choose to pay the education fee according to our standard model or apply for a partial payment through our financing partners.
+        The Craft Academy Boot Camp is a private education and thus does not qualify for CSN support. You can choose to pay the education fee according to our standard model or apply for a payment through our financing partners.
       %h3 Standard fee
       %table.responsive-table
         %thead.backgrounded
@@ -65,13 +65,13 @@
             %td{data:{header: 'Total'}}
               %strong
                 125 000 SEK
-          %tr
-            %td{data:{header: 'Program'}} React Front-End Developer
-            %td{data:{header: 'At registration'}} 5 900 SEK
-            %td{data:{header: 'At course start'}}  53 100 SEK
-            %td{data:{header: 'Total'}}
-              %strong
-                59 000 SEK
+          -# %tr
+          -#   %td{data:{header: 'Program'}} React Front-End Developer
+          -#   %td{data:{header: 'At registration'}} 5 900 SEK
+          -#   %td{data:{header: 'At course start'}}  53 100 SEK
+          -#   %td{data:{header: 'Total'}}
+          -#     %strong
+          -#       59 000 SEK
     .centered-row
       %h3 Female participants
       %p.copy--center
@@ -107,13 +107,13 @@
             %td{data:{header: 'Total at registration(incl. 25% VAT)'}}
               %strong
                 118 750 SEK
-          %tr
-            %td{data:{header: 'Program'}} React Front-End Developer
-            %td{data:{header: 'List price'}} 59 000 kr
-            %td{data:{header: 'Discount'}} 5%
-            %td{data:{header: 'Total at registration(incl. 25% VAT)'}}
-              %strong
-                56 050 kr
+          -# %tr
+          -#   %td{data:{header: 'Program'}} React Front-End Developer
+          -#   %td{data:{header: 'List price'}} 59 000 kr
+          -#   %td{data:{header: 'Discount'}} 5%
+          -#   %td{data:{header: 'Total at registration(incl. 25% VAT)'}}
+          -#     %strong
+          -#       56 050 kr
 
     -# .centered-row
     -#   %h3 Interest-free instalments  *

--- a/source/payment.html.haml
+++ b/source/payment.html.haml
@@ -1,4 +1,4 @@
-- description 'Våra priser - Grundpriset för Craft Academy\'s Full Stack Developer Bootcamp är 97 700 SEK. Titta efter aktuella erbjudanden.'
+- description 'Våra priser - Grundpriset för Craft Academy\'s Full Stack Developer Bootcamp är 99 500 SEK. Titta efter aktuella erbjudanden.'
 %section.hero-splash{style: "background-image: url(#{image_path('backgrounds/splash_4.jpg')});"}
   .container
     .centered-row
@@ -55,10 +55,10 @@
           %tr
             %td{data:{header: 'Program'}} Full Stack Web Developer
             %td{data:{header: 'Vid antagning'}} 9 700 kr
-            %td{data:{header: 'Vid kursstart'}} 87 300 kr
+            %td{data:{header: 'Vid kursstart'}} 89 800 kr
             %td{data:{header: 'Summa'}}
               %strong
-                97 000 kr
+                99 500 kr
           -# %tr
           -#   %td{data:{header: 'Program'}} Enterprise Java Web Application Developer
           -#   %td{data:{header: 'Vid antagning'}} 11 500 kr
@@ -73,13 +73,13 @@
             %td{data:{header: 'Summa'}}
               %strong
                 125 000 kr
-          %tr
-            %td{data:{header: 'Program'}} React Front-End Develooper
-            %td{data:{header: 'Vid antagning'}} 5 900 kr
-            %td{data:{header: 'Vid kursstart'}}  53 100 kr
-            %td{data:{header: 'Summa'}}
-              %strong
-                59 000 kr
+          -# %tr
+          -#   %td{data:{header: 'Program'}} React Front-End Develooper
+          -#   %td{data:{header: 'Vid antagning'}} 5 900 kr
+          -#   %td{data:{header: 'Vid kursstart'}}  53 100 kr
+          -#   %td{data:{header: 'Summa'}}
+          -#     %strong
+          -#       59 000 kr
     .centered-row
       %h3 Kvinnliga sökande
       %p.copy--center
@@ -97,11 +97,11 @@
         %tbody
           %tr
             %td{data:{header: 'Program'}} Full Stack Web Developer
-            %td{data:{header: 'Listpris'}} 97 000 kr
+            %td{data:{header: 'Listpris'}} 99 500 kr
             %td{data:{header: 'Rabatt'}} 5%
             %td{data:{header: 'Att betala vid antagning'}}
               %strong
-                92 150 kr
+                94 525 kr
           -# %tr
           -#   %td{data:{header: 'Program'}} Enterprise Java Web Application Developer
           -#   %td{data:{header: 'Listpris'}} 115 000 kr
@@ -116,13 +116,13 @@
             %td{data:{header: 'Summa'}}
               %strong
                 118 750 kr
-          %tr
-            %td{data:{header: 'Program'}} React Front-End Developer
-            %td{data:{header: 'Vid antagning'}} 59 000 kr
-            %td{data:{header: 'Rabatt'}} 5%
-            %td{data:{header: 'Summa'}}
-              %strong
-                56 050 kr
+          -# %tr
+          -#   %td{data:{header: 'Program'}} React Front-End Developer
+          -#   %td{data:{header: 'Vid antagning'}} 59 000 kr
+          -#   %td{data:{header: 'Rabatt'}} 5%
+          -#   %td{data:{header: 'Summa'}}
+          -#     %strong
+          -#       56 050 kr
     -# .centered-row
     -#   %h3 Räntefri Delbetalning *
     -#   %table.responsive-table


### PR DESCRIPTION
- Increasing the price of the Bootcamp for next year
- changed from 97 000 to 99 500 SEK, both English and Swedish site
- removing the React Frontend course from the pricing pages from both in English and Swedish
![Screenshot 2019-12-02 at 10 53 04](https://user-images.githubusercontent.com/41902068/69949959-c18b6280-14f2-11ea-826f-293edb442637.png)
![Screenshot 2019-12-02 at 10 53 40](https://user-images.githubusercontent.com/41902068/69949961-c3552600-14f2-11ea-8082-f2b0077bc26d.png)
