### PR TITLE
Downgrading haml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'neat', '~> 1.7.2'
 
 gem 'middleman-dotenv', '~> 1.0'
 gem 'middleman-deploy', '~> 1.0'
-
+gem 'haml', '~> 4.0', '>= 4.0.7'
 gem 'puma', '~> 2.7'
 
 # security updates

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,7 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     ffi (1.9.25)
-    haml (5.1.1)
-      temple (>= 0.8.0)
+    haml (4.0.7)
       tilt
     hike (1.2.3)
     hitimes (1.3.1)
@@ -159,7 +158,6 @@ GEM
     sprockets-sass (1.3.1)
       sprockets (~> 2.0)
       tilt (~> 1.1)
-    temple (0.8.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (1.4.1)
@@ -178,6 +176,7 @@ PLATFORMS
 
 DEPENDENCIES
   ffi (~> 1.9.24)
+  haml (~> 4.0, >= 4.0.7)
   middleman (~> 3.3.12)
   middleman-deploy (~> 1.0)
   middleman-dotenv (~> 1.0)

--- a/config.rb
+++ b/config.rb
@@ -126,14 +126,14 @@ redirect 'pretoria.html', to: 'south-africa.html'
 redirect 'south-africa.html', to: 'english/za/index.html'
 
 # HACK: Comment this section out while in development
-activate :deploy do |deploy|
-  deploy.method          = :rsync
-  deploy.host            = ENV.fetch('HOST')
-  deploy.path            = ENV.fetch('DEPLOY_PATH')
-  deploy.user            = ENV.fetch('DEPLOY_USER')
-  deploy.build_before    = true
-  deploy.clean           = true
-end
+# activate :deploy do |deploy|
+#   deploy.method          = :rsync
+#   deploy.host            = ENV.fetch('HOST')
+#   deploy.path            = ENV.fetch('DEPLOY_PATH')
+#   deploy.user            = ENV.fetch('DEPLOY_USER')
+#   deploy.build_before    = true
+#   deploy.clean           = true
+# end
 
 configure :development do
   activate :livereload

--- a/config.rb
+++ b/config.rb
@@ -126,14 +126,14 @@ redirect 'pretoria.html', to: 'south-africa.html'
 redirect 'south-africa.html', to: 'english/za/index.html'
 
 # HACK: Comment this section out while in development
-# activate :deploy do |deploy|
-#   deploy.method          = :rsync
-#   deploy.host            = ENV.fetch('HOST')
-#   deploy.path            = ENV.fetch('DEPLOY_PATH')
-#   deploy.user            = ENV.fetch('DEPLOY_USER')
-#   deploy.build_before    = true
-#   deploy.clean           = true
-# end
+activate :deploy do |deploy|
+  deploy.method          = :rsync
+  deploy.host            = ENV.fetch('HOST')
+  deploy.path            = ENV.fetch('DEPLOY_PATH')
+  deploy.user            = ENV.fetch('DEPLOY_USER')
+  deploy.build_before    = true
+  deploy.clean           = true
+end
 
 configure :development do
   activate :livereload

--- a/source/curriculum.html.haml
+++ b/source/curriculum.html.haml
@@ -12,7 +12,7 @@
       = link_to 'Veckoplan', '/weekly_plan', class: 'button button--vertical'
   .container
   %br
-  %br
+  -# %br
   -# .container
   -#   .centered-row
   -#     %h2 React Front-End Developer

--- a/source/partials/curriculum/_react_curriculum_vertical.html.haml
+++ b/source/partials/curriculum/_react_curriculum_vertical.html.haml
@@ -1,19 +1,19 @@
 
 
-%section
-  .container
-    .definition-row
-      %aside#definition-top
-        %nav.definition-links
-          - data.react_curriculum_week.each_with_index do |week, index|
-            %a.definition-link{href: "#definition-#{index}"}= week[:title]
-      %article
-        - data.react_curriculum_week.each_with_index do |week, index|
-          .category
-            %h4{id: "definition-#{index}"}= week[:title]
-            %dl.definition{id: slug(week[:title])}
-              %dt= week[:summary]
-              %dd
-                %p= week[:blurb]
-    .centered-row
-      = link_to 'Tillbaka', '/curriculum', class: 'button button--vertical'
+-# %section
+-#   .container
+-#     .definition-row
+-#       %aside#definition-top
+-#         %nav.definition-links
+-#           - data.react_curriculum_week.each_with_index do |week, index|
+-#             %a.definition-link{href: "#definition-#{index}"}= week[:title]
+-#       %article
+-#         - data.react_curriculum_week.each_with_index do |week, index|
+-#           .category
+-#             %h4{id: "definition-#{index}"}= week[:title]
+-#             %dl.definition{id: slug(week[:title])}
+-#               %dt= week[:summary]
+-#               %dd
+-#                 %p= week[:blurb]
+-#     .centered-row
+-#       = link_to 'Tillbaka', '/curriculum', class: 'button button--vertical'


### PR DESCRIPTION
- fixing a deployment issue
- Downgraded haml to 4.0.7 from 5.1.1
- commented out everything in react_curriculum_vertical.html.haml, so that the middleman build will run without errors