### PR TITLE
April Bootcamp Dates

### DIFF
--- a/data/intakes.yml
+++ b/data/intakes.yml
@@ -27,9 +27,16 @@
   course: Full Stack Web Developer Bootcamp
   price: 97 000
 
-- start_date: 3 February 2020
+- start_date: 3 February 2020 
   end_date: 24 April 2020
   precourse_start_date: 6 January 2020
   locations: "Göteborg, Stockholm, Remote"
-  course: Full Stack Web Developer Bootcamp
+  course: Full Stack Web Developer Bootcamp - NO SEATS AVAILABLE
   price: 97 000
+
+- start_date: 6 April 2020
+  end_date: 27 June 2020
+  precourse_start_date: 9 March 2020
+  locations: "Göteborg, Stockholm, Remote"
+  course: Full Stack Web Developer Bootcamp
+  price: 99 500


### PR DESCRIPTION
- Updating the new dates for the April Bootcamp
- Added a message to say "no seats available" to the February Bootcamp

![Screenshot 2019-12-09 at 10 33 43](https://user-images.githubusercontent.com/41902068/70424492-c78fbf00-1a6f-11ea-890c-9ad6d88d2730.png)
![Screenshot 2019-12-09 at 10 33 53](https://user-images.githubusercontent.com/41902068/70424497-c9598280-1a6f-11ea-8015-a5b01c1aa7d6.png)
