### PR TITLE
 2021 Bootcamp dates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,8 +193,5 @@ DEPENDENCIES
   sprockets (~> 2.12.5)
   timecop
 
-RUBY VERSION
-   ruby 2.5.1p57
-
 BUNDLED WITH
    1.17.3

--- a/data/intakes.yml
+++ b/data/intakes.yml
@@ -80,3 +80,27 @@
   locations: "Göteborg, Stockholm, Nomads (remote)"
   course: Full Stack Web Developer Bootcamp/ Nomads
   price: 99 500
+
+- start_date: 8 February 2021
+  end_date: 30 April 2021
+  deadline: 27 January 2021
+  precourse_start_date: 1 February 2021
+  locations: "Göteborg, Stockholm, Nomads (remote)"
+  course: Cybint Cyber Security Specialist
+  price: 115 000
+
+- start_date: 29 March 2021
+  end_date: 19 June 2021
+  deadline: 24 February 2021
+  precourse_start_date: 1 March 2021
+  locations: "Göteborg, Stockholm, Nomads (remote)"
+  course: Full Stack Web Developer Bootcamp/ Nomads
+  price: 99 500
+
+- start_date: 7 June 2021
+  end_date: 11 September 2021
+  deadline: 5 May 2021
+  precourse_start_date: 10 May 2021
+  locations: "Göteborg, Stockholm, Nomads (remote)"
+  course: Full Stack Web Developer Bootcamp/ Nomads
+  price: 99 500


### PR DESCRIPTION
- Added dates for the March & June Bootcamp for 2021
- Added the new date for the Cyber Security course

![Screenshot 2020-12-16 at 16 15 47](https://user-images.githubusercontent.com/41902068/102367499-24468380-3fba-11eb-99a6-ca9f128a7ed5.png)
